### PR TITLE
Change .post-quote overflow value to auto

### DIFF
--- a/app/assets/stylesheets/pants.css.scss
+++ b/app/assets/stylesheets/pants.css.scss
@@ -211,7 +211,7 @@ div.post-quote {
   padding: 1px 20px;
   border-left: 10px solid #eee;
   max-height: 200px;
-  overflow: scroll;
+  overflow: auto;
 }
 
 // TIMELINE ENTRIES


### PR DESCRIPTION
It was set to `scroll`, which always shows scrollbars, even if they aren't needed. This is probably not what you want. You want to `auto`matically show scrollbars, if the content exceeds the height of the div. 

Happy Panting \o/
