### PR TITLE
Natural scrolling for iOS on reference body.

### DIFF
--- a/app/assets/stylesheets/pantastic/_posts.scss
+++ b/app/assets/stylesheets/pantastic/_posts.scss
@@ -116,6 +116,8 @@ article.post>header {
 
   max-height: 240px;
   overflow: auto;
+  // natural scrolling for ios devices
+  -webkit-overflow-scrolling: touch;
   position: relative;
   padding: 15px 20px;
 


### PR DESCRIPTION
Reference bodies have `overflow: auto`, but do not behave like other scrollable areas on ios devices. 
Adding `-webkit-overflow-scrolling: touch` to them fixes this.
