### PR TITLE
Fixes button styling for iOS devices.

### DIFF
--- a/app/assets/stylesheets/pantastic/_forms.scss
+++ b/app/assets/stylesheets/pantastic/_forms.scss
@@ -30,6 +30,7 @@ input, textarea, select, option {
 
 input.string, input[type="text"], input[type="email"], input[type="password"], textarea {
   @extend %form-field-styling;
+  -webkit-appearance: none;
   &:focus {
     border-color: $color-theme;
   }
@@ -37,6 +38,7 @@ input.string, input[type="text"], input[type="email"], input[type="password"], t
 
 input[type="submit"], button {
   @extend %button;
+  -webkit-appearance: none;
 }
 
 input[type="submit"] {


### PR DESCRIPTION
Apple does not allow to style `input[type="submit"]` and `button`, unless you tell 'em so.

_Note:_ I intentionally did not add this into the `_protoypes.scss` file, because it is `input[type="submit"], button` specific.
