### PR TITLE
Changed Procfile target and database connections

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-pants: puma -p $PORT -w 2 -t 2:8
+web: bundle exec puma -p $PORT -w 2 -t 2:8

--- a/config/database.yml
+++ b/config/database.yml
@@ -80,6 +80,7 @@ test:
 #
 production:
   <<: *default
-  database: pants_production
-  username: pants
+  host: <%= ENV['PANTS_DATABASE_HOSTNAME'] %>
+  database: <%= ENV['PANTS_DATABASE_DB'] %>
+  username: <%= ENV['PANTS_DATABASE_USERNAME'] %>
   password: <%= ENV['PANTS_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
Hi Hendrik,

I needed to change two files for my dokku deployment of #pants.
## the Procfile

dokku has some default process types for rails applications:

```
-----> Discovering process types
       Procfile declares types -> web
       Default process types for Ruby -> rake, console, web, worker
```

If the Procfile defines "pants" as a Process type, the app won't start. This is, why I changed it to "web".
## Database configuration

My database username is not pants, neither is my database name pants_production. Having full control over database.yml with environment parameters simplified the dokku deployment.

With those two changes, pants deployments with dokku will work out of the box.

Cheers
Dennis
